### PR TITLE
feat: add dependabot groups for minor/patch and major updates

### DIFF
--- a/shared-files/dependabot/dependabot.yml.njk
+++ b/shared-files/dependabot/dependabot.yml.njk
@@ -6,15 +6,39 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions-minor:
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        update-types:
+          - "major"
 {% if golang %}
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      gomod-minor:
+        update-types:
+          - "minor"
+          - "patch"
+      gomod-major:
+        update-types:
+          - "major"
 {% endif %}
 {% if terraform %}
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      terraform-minor:
+        update-types:
+          - "minor"
+          - "patch"
+      terraform-major:
+        update-types:
+          - "major"
 {% endif %}


### PR DESCRIPTION
## Summary

This PR adds dependabot update groups to the shared template, for all supported ecosystems.

- **Minor & patch** updates are grouped together (less noise, auto-mergeable candidates)
- **Major** updates are kept in a separate group (intentionally isolated for manual review)

### Ecosystems covered

| Ecosystem | Minor+patch group | Major group |
|---|---|---|
| `github-actions` | `github-actions-minor` | `github-actions-major` |
| `gomod` (if enabled) | `gomod-minor` | `gomod-major` |
| `terraform` (if enabled) | `terraform-minor` | `terraform-major` |

All Nunjucks conditionals (`{% if golang %}`, `{% if terraform %}`) are preserved as-is.